### PR TITLE
[fix] int to Integer

### DIFF
--- a/insta/src/main/java/com/posco/insta/user/controller/UserController.java
+++ b/insta/src/main/java/com/posco/insta/user/controller/UserController.java
@@ -25,7 +25,7 @@ public class UserController {
     }
 
     @PostMapping("/")
-    public int createPost(@RequestParam String userId, @RequestParam String img, @RequestParam String name, @RequestParam String password){
+    public Integer createPost(@RequestParam String userId, @RequestParam String img, @RequestParam String name, @RequestParam String password){
         UserDto userDto = new UserDto();
         userDto.setUserId(userId);
         userDto.setImg(img);

--- a/insta/src/main/java/com/posco/insta/user/repository/UserMapper.java
+++ b/insta/src/main/java/com/posco/insta/user/repository/UserMapper.java
@@ -10,7 +10,7 @@ public interface UserMapper {
     List<UserDto> getUser();
     UserDto getUserById(UserDto userDto);
 
-    int insertUser(UserDto userDto);
+    Integer insertUser(UserDto userDto);
 
     Integer deleteUser(UserDto userDto);
 }

--- a/insta/src/main/java/com/posco/insta/user/service/UserService.java
+++ b/insta/src/main/java/com/posco/insta/user/service/UserService.java
@@ -9,7 +9,7 @@ import java.util.List;
 public interface UserService {
     List<UserDto> findUser();
     UserDto findUserById(UserDto userDto);
-    int insertUser(UserDto userDto);
+    Integer insertUser(UserDto userDto);
     Integer deleteUser(UserDto userDto);
 
 }

--- a/insta/src/main/java/com/posco/insta/user/service/UserServiceImpl.java
+++ b/insta/src/main/java/com/posco/insta/user/service/UserServiceImpl.java
@@ -22,7 +22,7 @@ public class UserServiceImpl implements UserService{
     }
 
     @Override
-    public int insertUser(UserDto userDto) {
+    public Integer insertUser(UserDto userDto) {
       return userMapper.insertUser(userDto);
 
     }


### PR DESCRIPTION
## issue
#3 

## 이유
Integer :객체이자 null 값 처리가 용이하기 때문에 SQL과 연동할 경우 처리가 용이하다.
